### PR TITLE
Change monitor action run always

### DIFF
--- a/monitor/action.yml
+++ b/monitor/action.yml
@@ -17,4 +17,4 @@ runs:
   using: 'node16'
   main: 'dist/index.js'
   post: 'dist/index.js'
-  post-if: success()
+  post-if: always()


### PR DESCRIPTION
Changed the 'post-if' condition in 'monitor/action.yml' from 'success()' to 'always()'. This change ensures that the post-workflow actions are executed in all scenarios, not only when the main steps are successful.

Some workflows also have permissions used by steps that only run on failure (such as notifications) because I want to collect these.