### PR TITLE
Add Elixir Hex’s `HEX_CACERTS_PATH` configuration in monitor setup script

### DIFF
--- a/monitor/setup.sh
+++ b/monitor/setup.sh
@@ -44,6 +44,8 @@ if [ "$RUNNER_OS" = "macOS" ]; then
   echo "NODE_EXTRA_CA_CERTS=/Users/mitmproxyuser/.mitmproxy/mitmproxy-ca-cert.pem" >> $GITHUB_ENV
   # set environment variable for the Python requests library to use the certificate
   echo "REQUESTS_CA_BUNDLE=/Users/mitmproxyuser/.mitmproxy/mitmproxy-ca-cert.pem" >> $GITHUB_ENV
+  # set environment variable for the Elixir Hex package manager to use the certificate
+  echo "HEX_CACERTS_PATH=/Users/mitmproxyuser/.mitmproxy/mitmproxy-ca-cert.pem" >> $GITHUB_ENV
 
   # Enable IP forwarding.
   sudo sysctl -w net.inet.ip.forwarding=1

--- a/monitor/setup.sh
+++ b/monitor/setup.sh
@@ -114,6 +114,8 @@ elif [ "$RUNNER_OS" = "Linux" ]; then
   echo "NODE_EXTRA_CA_CERTS=/home/mitmproxyuser/.mitmproxy/mitmproxy-ca-cert.pem" >> $GITHUB_ENV
   # set environment variable for the Python requests library to use the certificate
   echo "REQUESTS_CA_BUNDLE=/home/mitmproxyuser/.mitmproxy/mitmproxy-ca-cert.pem" >> $GITHUB_ENV
+  # set environment variable for the Elixir Hex package manager to use the certificate
+  echo "HEX_CACERTS_PATH=/home/mitmproxyuser/.mitmproxy/mitmproxy-ca-cert.pem" >> $GITHUB_ENV
 
   # setup global redirection
   sudo sysctl -w net.ipv4.ip_forward=1


### PR DESCRIPTION
This pull request adds the `HEX_CACERTS_PATH` environment variable so Elixir commands like `mix deps.get` (which makes HTTPS requests) will correctly go through `mitmproxy`.

This should fix #4.

### References

- https://github.com/hexpm/hex/pull/727
- https://hexdocs.pm/hex/Mix.Tasks.Hex.Config.html#module-config-keys