### PR TITLE
Add mitmproxy certificate authority to Docker configuration

### DIFF
--- a/monitor/setup.sh
+++ b/monitor/setup.sh
@@ -116,6 +116,10 @@ elif [ "$RUNNER_OS" = "Linux" ]; then
   echo "REQUESTS_CA_BUNDLE=/home/mitmproxyuser/.mitmproxy/mitmproxy-ca-cert.pem" >> $GITHUB_ENV
   # set environment variable for the Elixir Hex package manager to use the certificate
   echo "HEX_CACERTS_PATH=/home/mitmproxyuser/.mitmproxy/mitmproxy-ca-cert.pem" >> $GITHUB_ENV
+  # copy certificate to Docker directory
+  sudo mkdir -p /etc/docker/certs.d/registry-1.docker.io:443
+  sudo cp ~/mitmproxy-ca-cert.crt /etc/docker/certs.d/registry-1.docker.io:443
+  sudo service docker restart
 
   # setup global redirection
   sudo sysctl -w net.ipv4.ip_forward=1


### PR DESCRIPTION
Like #5, let’s add another configuration for another tool 😅 ([successfully tested here](https://github.com/mirego/elixir-boilerplate/actions/runs/5404058499/jobs/9817731997#step:9:21)).

Docker supports custom certificates in `/etc/docker/certs.d/<host>:<port>` ([reference](https://docs.docker.com/engine/security/certificates/#understand-the-configuration)).

GitHub-provided macOS runners [do not have Docker running](https://github.com/search?q=repo%3Aactions%2Frunner-images+docker+path%3Amacos&type=code) so it’s only for Ubuntu runners.