### PR TITLE
Only install Python from `deadsnakes` on Ubuntu versions prior to 22.04

### DIFF
--- a/monitor/setup.sh
+++ b/monitor/setup.sh
@@ -112,9 +112,16 @@ if [ "$RUNNER_OS" = "macOS" ]; then
 
 elif [ "$RUNNER_OS" = "Linux" ]; then
 
+  # ubuntu 22.04 and later install python 3.10 or later by default
+  python_package="python3"
+
   # install python 3.10, otherwise ubuntu 20.04 installs 3.8 and we won't get the latest mitmproxy with important bug fixes
-  sudo add-apt-repository ppa:deadsnakes/ppa -y
-  sudo apt install -y python3.10-venv
+  if (( "$(lsb_release --short --release | cut --delimiter='.' --fields=1)" < 22 )); then
+    sudo add-apt-repository ppa:deadsnakes/ppa -y
+    python_package="python3.10"
+  fi
+
+  sudo apt install -y "$python_package"-venv
 
   # create mitmproxyuser, otherwise proxy won't intercept local trafic from the same user
   sudo useradd --create-home mitmproxyuser
@@ -125,7 +132,7 @@ elif [ "$RUNNER_OS" = "Linux" ]; then
                                        git clone -b main https://github.com/mitmproxy/mitmproxy.git && \
                                        cd mitmproxy && \
                                        git checkout 5353df5f1eeaf5fc36d9b5f7024199c888aed116 && \
-                                       python3.10 -m venv venv && \
+                                       "$(command -v python3.10 || command -v python3)" -m venv venv && \
                                        venv/bin/pip install -e ".[dev]" '
 
   sudo cp mitm_plugin.py /home/mitmproxyuser/mitm_plugin.py


### PR DESCRIPTION
The install of Python 3.10 from [deadsnakes](https://launchpad.net/~deadsnakes/+archive/ubuntu/ppa) is only necessary on Ubuntu versions prior to 22.04. Ubuntu 22.04 ships with [Python 3.10.6](https://launchpad.net/ubuntu/jammy/+package/python3) and 24.04 ships with [Python 3.12.3](https://launchpad.net/ubuntu/noble/+package/python3). When using GitHub hosted runners the `ubuntu-latest` tag corresponds with `ubuntu-22.04` and at some point will correspond with `ubuntu-24.04` so tying everything to the needs of `ubuntu-20.04` seems unnecessary.