### PR TITLE
Configure the `AWS_CA_BUNDLE` environment variable

### DIFF
--- a/monitor/setup.sh
+++ b/monitor/setup.sh
@@ -63,6 +63,8 @@ if [ "$RUNNER_OS" = "macOS" ]; then
   echo "REQUESTS_CA_BUNDLE=/Users/mitmproxyuser/.mitmproxy/mitmproxy-ca-cert.pem" >> $GITHUB_ENV
   # set environment variable for the Elixir Hex package manager to use the certificate
   echo "HEX_CACERTS_PATH=/Users/mitmproxyuser/.mitmproxy/mitmproxy-ca-cert.pem" >> $GITHUB_ENV
+  # set environment variable for AWS tools
+  echo "AWS_CA_BUNDLE=/Users/mitmproxyuser/.mitmproxy/mitmproxy-ca-cert.pem" >> $GITHUB_ENV
 
   # Enable IP forwarding.
   sudo sysctl -w net.inet.ip.forwarding=1
@@ -175,6 +177,8 @@ elif [ "$RUNNER_OS" = "Linux" ]; then
   echo "REQUESTS_CA_BUNDLE=/home/mitmproxyuser/.mitmproxy/mitmproxy-ca-cert.pem" >> $GITHUB_ENV
   # set environment variable for the Elixir Hex package manager to use the certificate
   echo "HEX_CACERTS_PATH=/home/mitmproxyuser/.mitmproxy/mitmproxy-ca-cert.pem" >> $GITHUB_ENV
+  # set environment variable for AWS tools
+  echo "AWS_CA_BUNDLE=/home/mitmproxyuser/.mitmproxy/mitmproxy-ca-cert.pem" >> $GITHUB_ENV
 
   # setup global redirection
   sudo sysctl -w net.ipv4.ip_forward=1


### PR DESCRIPTION
This environment variable is used by AWS tools (AWS CLI, Botocore, etc.) to specify a path to a certificate bundle for use for HTTPS certificate validation. We experienced the following error with the current release of this Action:

```log
Traceback (most recent call last):
  File \"/opt/hostedtoolcache/Python/3.12.8/x64/lib/python3.12/site-packages/urllib3/connectionpool.py\", line 466, in _make_request
    self._validate_conn(conn)
  File \"/opt/hostedtoolcache/Python/3.12.8/x64/lib/python3.12/site-packages/urllib3/connectionpool.py\", line 1095, in _validate_conn
    conn.connect()
  File \"/opt/hostedtoolcache/Python/3.12.8/x64/lib/python3.12/site-packages/urllib3/connection.py\", line 730, in connect
    sock_and_verified = _ssl_wrap_socket_and_match_hostname(
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File \"/opt/hostedtoolcache/Python/3.12.8/x64/lib/python3.12/site-packages/urllib3/connection.py\", line 909, in _ssl_wrap_socket_and_match_hostname
    ssl_sock = ssl_wrap_socket(
               ^^^^^^^^^^^^^^^^
  File \"/opt/hostedtoolcache/Python/3.12.8/x64/lib/python3.12/site-packages/urllib3/util/ssl_.py\", line 469, in ssl_wrap_socket
    ssl_sock = _ssl_wrap_socket_impl(sock, context, tls_in_tls, server_hostname)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File \"/opt/hostedtoolcache/Python/3.12.8/x64/lib/python3.12/site-packages/urllib3/util/ssl_.py\", line 513, in _ssl_wrap_socket_impl
    return ssl_context.wrap_socket(sock, server_hostname=server_hostname)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File \"/opt/hostedtoolcache/Python/3.12.8/x64/lib/python3.12/ssl.py\", line 455, in wrap_socket
    return self.sslsocket_class._create(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File \"/opt/hostedtoolcache/Python/3.12.8/x64/lib/python3.12/ssl.py\", line 1041, in _create
    self.do_handshake()
  File \"/opt/hostedtoolcache/Python/3.12.8/x64/lib/python3.12/ssl.py\", line 1319, in do_handshake
    self._sslobj.do_handshake()
ssl.SSLCertVerificationError: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate (_ssl.c:1000)

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File \"/opt/hostedtoolcache/Python/3.12.8/x64/lib/python3.12/site-packages/botocore/httpsession.py\", line 464, in send
    urllib_response = conn.urlopen(
                      ^^^^^^^^^^^^^
  File \"/opt/hostedtoolcache/Python/3.12.8/x64/lib/python3.12/site-packages/urllib3/connectionpool.py\", line 843, in urlopen
    retries = retries.increment(
              ^^^^^^^^^^^^^^^^^^
  File \"/opt/hostedtoolcache/Python/3.12.8/x64/lib/python3.12/site-packages/urllib3/util/retry.py\", line 449, in increment
    raise reraise(type(error), error, _stacktrace)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File \"/opt/hostedtoolcache/Python/3.12.8/x64/lib/python3.12/site-packages/urllib3/util/util.py\", line 39, in reraise
    raise value
  File \"/opt/hostedtoolcache/Python/3.12.8/x64/lib/python3.12/site-packages/urllib3/connectionpool.py\", line 789, in urlopen
    response = self._make_request(
               ^^^^^^^^^^^^^^^^^^^
  File \"/opt/hostedtoolcache/Python/3.12.8/x64/lib/python3.12/site-packages/urllib3/connectionpool.py\", line 490, in _make_request
    raise new_e
urllib3.exceptions.SSLError: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate (_ssl.c:1000)

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File \"/tmp/ansible_amazon.aws.s3_object_payload_yyhw7smb/ansible_amazon.aws.s3_object_payload.zip/ansible_collections/amazon/aws/plugins/modules/s3_object.py\", line 554, in bucket_check
  File \"/tmp/ansible_amazon.aws.s3_object_payload_yyhw7smb/ansible_amazon.aws.s3_object_payload.zip/ansible_collections/amazon/aws/plugins/module_utils/retries.py\", line 105, in deciding_wrapper
  File \"/tmp/ansible_amazon.aws.s3_object_payload_yyhw7smb/ansible_amazon.aws.s3_object_payload.zip/ansible_collections/amazon/aws/plugins/module_utils/cloud.py\", line 119, in _retry_wrapper
  File \"/tmp/ansible_amazon.aws.s3_object_payload_yyhw7smb/ansible_amazon.aws.s3_object_payload.zip/ansible_collections/amazon/aws/plugins/module_utils/cloud.py\", line 68, in _retry_func
  File \"/opt/hostedtoolcache/Python/3.12.8/x64/lib/python3.12/site-packages/botocore/client.py\", line 569, in _api_call
    return self._make_api_call(operation_name, kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File \"/opt/hostedtoolcache/Python/3.12.8/x64/lib/python3.12/site-packages/botocore/client.py\", line 1005, in _make_api_call
    http, parsed_response = self._make_request(
                            ^^^^^^^^^^^^^^^^^^^
  File \"/opt/hostedtoolcache/Python/3.12.8/x64/lib/python3.12/site-packages/botocore/client.py\", line 1029, in _make_request
    return self._endpoint.make_request(operation_model, request_dict)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File \"/opt/hostedtoolcache/Python/3.12.8/x64/lib/python3.12/site-packages/botocore/endpoint.py\", line 119, in make_request
    return self._send_request(request_dict, operation_model)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File \"/opt/hostedtoolcache/Python/3.12.8/x64/lib/python3.12/site-packages/botocore/endpoint.py\", line 200, in _send_request
    while self._needs_retry(
          ^^^^^^^^^^^^^^^^^^
  File \"/opt/hostedtoolcache/Python/3.12.8/x64/lib/python3.12/site-packages/botocore/endpoint.py\", line 360, in _needs_retry
    responses = self._event_emitter.emit(
                ^^^^^^^^^^^^^^^^^^^^^^^^^
  File \"/opt/hostedtoolcache/Python/3.12.8/x64/lib/python3.12/site-packages/botocore/hooks.py\", line 412, in emit
    return self._emitter.emit(aliased_event_name, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File \"/opt/hostedtoolcache/Python/3.12.8/x64/lib/python3.12/site-packages/botocore/hooks.py\", line 256, in emit
    return self._emit(event_name, kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File \"/opt/hostedtoolcache/Python/3.12.8/x64/lib/python3.12/site-packages/botocore/hooks.py\", line 239, in _emit
    response = handler(**kwargs)
               ^^^^^^^^^^^^^^^^^
  File \"/opt/hostedtoolcache/Python/3.12.8/x64/lib/python3.12/site-packages/botocore/retryhandler.py\", line 207, in __call__
    if self._checker(**checker_kwargs):
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File \"/opt/hostedtoolcache/Python/3.12.8/x64/lib/python3.12/site-packages/botocore/retryhandler.py\", line 284, in __call__
    should_retry = self._should_retry(
                   ^^^^^^^^^^^^^^^^^^^
  File \"/opt/hostedtoolcache/Python/3.12.8/x64/lib/python3.12/site-packages/botocore/retryhandler.py\", line 320, in _should_retry
    return self._checker(attempt_number, response, caught_exception)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File \"/opt/hostedtoolcache/Python/3.12.8/x64/lib/python3.12/site-packages/botocore/retryhandler.py\", line 363, in __call__
    checker_response = checker(
                       ^^^^^^^^
  File \"/opt/hostedtoolcache/Python/3.12.8/x64/lib/python3.12/site-packages/botocore/retryhandler.py\", line 247, in __call__
    return self._check_caught_exception(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File \"/opt/hostedtoolcache/Python/3.12.8/x64/lib/python3.12/site-packages/botocore/retryhandler.py\", line 416, in _check_caught_exception
    raise caught_exception
  File \"/opt/hostedtoolcache/Python/3.12.8/x64/lib/python3.12/site-packages/botocore/endpoint.py\", line 279, in _do_get_response
    http_response = self._send(request)
                    ^^^^^^^^^^^^^^^^^^^
  File \"/opt/hostedtoolcache/Python/3.12.8/x64/lib/python3.12/site-packages/botocore/endpoint.py\", line 383, in _send
    return self.http_session.send(request)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File \"/opt/hostedtoolcache/Python/3.12.8/x64/lib/python3.12/site-packages/botocore/httpsession.py\", line 491, in send
    raise SSLError(endpoint_url=request.url, error=e)
botocore.exceptions.SSLError: SSL validation failed for https://***.s3.amazonaws.com/ [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate (_ssl.c:1000)

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File \"/home/runner/.ansible/tmp/ansible-tmp-1734113966.717507-9951-146204688662132/AnsiballZ_s3_object.py\", line 107, in <module>
    _ansiballz_main()
  File \"/home/runner/.ansible/tmp/ansible-tmp-1734113966.717507-9951-146204688662132/AnsiballZ_s3_object.py\", line 99, in _ansiballz_main
    invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)
  File \"/home/runner/.ansible/tmp/ansible-tmp-1734113966.717507-9951-146204688662132/AnsiballZ_s3_object.py\", line 47, in invoke_module
    runpy.run_module(mod_name='ansible_collections.amazon.aws.plugins.modules.s3_object', init_globals=dict(_module_fqn='ansible_collections.amazon.aws.plugins.modules.s3_object', _modlib_path=modlib_path),
  File \"<frozen runpy>\", line 226, in run_module
  File \"<frozen runpy>\", line 98, in _run_module_code
  File \"<frozen runpy>\", line 88, in _run_code
  File \"/tmp/ansible_amazon.aws.s3_object_payload_yyhw7smb/ansible_amazon.aws.s3_object_payload.zip/ansible_collections/amazon/aws/plugins/modules/s3_object.py\", line 1607, in <module>
  File \"/tmp/ansible_amazon.aws.s3_object_payload_yyhw7smb/ansible_amazon.aws.s3_object_payload.zip/ansible_collections/amazon/aws/plugins/modules/s3_object.py\", line 1580, in main
  File \"/tmp/ansible_amazon.aws.s3_object_payload_yyhw7smb/ansible_amazon.aws.s3_object_payload.zip/ansible_collections/amazon/aws/plugins/modules/s3_object.py\", line 1447, in validate_bucket
  File \"/tmp/ansible_amazon.aws.s3_object_payload_yyhw7smb/ansible_amazon.aws.s3_object_payload.zip/ansible_collections/amazon/aws/plugins/modules/s3_object.py\", line 576, in bucket_check
S3ObjectFailure: Failed while looking up bucket '***' (during bucket_check).
", "module_stdout": "", "msg": "MODULE FAILURE
See stdout/stderr for the exact error
```

With this branch used the same workflow completes with no issue.