### PR TITLE
Reduce warnings by using apt-get instead of apt

### DIFF
--- a/monitor/setup.sh
+++ b/monitor/setup.sh
@@ -121,7 +121,9 @@ elif [ "$RUNNER_OS" = "Linux" ]; then
     python_package="python3.12"
   fi
 
-  sudo apt install -y "$python_package"-venv
+  sudo DEBIAN_FRONTEND=noninteractive \
+    apt-get install --yes --no-install-recommends \
+      "$python_package"-venv
 
   # create mitmproxyuser, otherwise proxy won't intercept local trafic from the same user
   sudo useradd --create-home mitmproxyuser


### PR DESCRIPTION
And also add in some other best practices options:

* Prevent any prompt blocks with `DEBIAN_FRONTEND=noninteractive`, although they shouldn't happen with this one package
* Avoid recommended packages with `--no-install-recommends`
* Expand `-y` to `--yes` because long options are better in scripts

Formatted such that the important parts of the command are easily visible: `sudo apt-get install $pkg` and the rest are just kinda cruft to the right!

Fixes #41 